### PR TITLE
add nationalST container for running eacSTpredict package

### DIFF
--- a/build_scripts/nationalST__dev/%post
+++ b/build_scripts/nationalST__dev/%post
@@ -1,0 +1,4 @@
+%post
+    Rscript -e "install.packages('remotes')"
+    Rscript -e "remotes::install_github('SpatioTemporal', ref = '0df042c')"
+    Rscript -e "remotes::install_github('kaufman-lab/eacSTpredict')"

--- a/build_scripts/nationalST__dev/bootstrap
+++ b/build_scripts/nationalST__dev/bootstrap
@@ -1,0 +1,3 @@
+Bootstrap: docker
+From: rocker/r-ver:4.1
+

--- a/definition_files/nationalST__dev.def
+++ b/definition_files/nationalST__dev.def
@@ -1,0 +1,37 @@
+Bootstrap: docker
+From: rocker/r-ver:4.1
+
+
+
+#######################################
+%setup
+#######################################
+
+
+
+
+#######################################
+%files
+#######################################
+
+
+
+
+#######################################
+%post
+#######################################
+
+
+%post
+    Rscript -e "install.packages('remotes')"
+    Rscript -e "remotes::install_github('SpatioTemporal', ref = '0df042c')"
+    Rscript -e "remotes::install_github('kaufman-lab/eacSTpredict')"
+
+
+
+
+#######################################
+%environment
+#######################################
+
+


### PR DESCRIPTION
This container will be used to run national ST air pollution models on brain with a fixed version of SpatioTemporal and the latest version of eacSTpredict. 