### PR TITLE
update runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 jobs:
   check-def-files:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     outputs: 
       definitions: ${{ env.definitions }}
     steps:
@@ -42,7 +42,7 @@ jobs:
   build:
     name: Build
     needs: check-def-files
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env: 
       organization: kaufman-lab
     strategy:


### PR DESCRIPTION
ubuntu-18.04 was deprecated as a runner for GH actions in april 2023. see https://github.com/actions/runner-images/issues/6002